### PR TITLE
fixed: rotate 90deg on avatar placeholder #113

### DIFF
--- a/src/components/AvatarUploader.js
+++ b/src/components/AvatarUploader.js
@@ -22,6 +22,7 @@ const useStyles = makeStyles((theme) => ({
     backgroundColor: 'transparent',
     border: `1px solid ${theme.palette.text.primary}`,
     cursor: 'pointer',
+    transform: 'rotate(90deg)',
   },
 }));
 


### PR DESCRIPTION
To fix this, it was only necessary to add the rotation in the Avatar placeholder

<img width="1274" alt="Screen Shot 2020-10-18 at 11 31 44" src="https://user-images.githubusercontent.com/57037080/96365091-0da8bb00-1136-11eb-9dfd-77e7185d4798.png">
<img width="139" alt="Screen Shot 2020-10-18 at 11 31 38" src="https://user-images.githubusercontent.com/57037080/96365092-0ed9e800-1136-11eb-9fcd-fad3850a3c91.png">


if you were happy with my work you can verify me as a human, i would like to do it at the frontend level i feel bad interacting directly with the contract rs rs

[Hey! Check out my Circles profile!](https://circles.garden/profile/0x8F90cad203C310DaeDC5296bBB26FAcb7920aD17)