### PR TITLE
Improve user warning on recovery fail

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -97,7 +97,7 @@
     "buttonSubmit": "Submit",
     "errorRestoreFailedInvalidSeedphrase": "Your seed phrase is invalid.",
     "errorRestoreFailedUnknown": "Could not restore account due to an unknown error.",
-    "errorRestoreFailedUnknownSafe": "The account you try to restore is not registered.",
+    "errorRestoreFailedUnknownSafe": "The account you tried to restore is not registered.",
     "headingLogin": "Login",
     "linkSupport": "Go to support.",
     "successWelcome": "Successfully connected to account. Welcome!"


### PR DESCRIPTION
Ran into this when trying to recover an account that wasn't yet verified.

Current PR is for fixing grammar. Is the "past" verb tense correct, or do you like present tense for messages like this?

Also, submitted a PR that might better capture my own expectation. A friend got this message and seemed to assume it meant the account hadn't been created and she should regen, since she "had already registered".