### PR TITLE
Fix mid-sentence capitalization

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -296,7 +296,7 @@
   "Validation": {
     "bodyDoNotReset": "Do not reset your browser or you will need to recover your data with your seed phrase.",
     "bodyTrustDescription": "To receive your basic income,",
-    "bodyTrustDescriptionEmphasize": "Three people must trust your profile.",
+    "bodyTrustDescriptionEmphasize": "three people must trust your profile.",
     "buttonShareProfileLink": "Share Profile Link",
     "headingBuildYourWebOfTrust": "Verify your account",
     "tooltipLeftTrustConnections": "You need {connections} more trust connections before you can create your account"


### PR DESCRIPTION
Changed from:
> To receive your basic income, Three people must trust your profile.

to:
> To receive your basic income, three people must trust your profile.