### PR TITLE
[Improvement] Center onboarding & remove logo from sign up

### DIFF
--- a/src/components/OnboardingStepper.js
+++ b/src/components/OnboardingStepper.js
@@ -9,7 +9,6 @@ import Button from '~/components/Button';
 import ButtonBack from '~/components/ButtonBack';
 import Footer from '~/components/Footer';
 import Header from '~/components/Header';
-import Logo from '~/components/Logo';
 import View from '~/components/View';
 import translate from '~/services/locale';
 import { IconBack, IconClose } from '~/styles/icons';
@@ -94,9 +93,6 @@ const OnboardingStepper = ({
       </Header>
       <View>
         <Container maxWidth="sm">
-          <Box my={6}>
-            <Logo />
-          </Box>
           <Box textAlign="center">
             <OnboardingCurrentStep
               values={values}

--- a/src/components/Tutorial.js
+++ b/src/components/Tutorial.js
@@ -58,7 +58,7 @@ const Tutorial = (props) => {
         onPrevious={onPrevious}
         onSkip={onFinish}
       />
-      <View>
+      <View mt={'auto'} mb={'auto'}>
         <Container maxWidth="sm">
           <SwipeableViews index={current} onChangeIndex={handleChangeIndex}>
             {props.slides}


### PR DESCRIPTION
Small PR. This vertically centers the tutorial screens and removes the logo from the form the onboarding/sign-up screens, to reduce keyboard interference with form fields.