### PR TITLE
[Improvement] numbered seed phrase

### DIFF
--- a/src/components/Mnemonic.js
+++ b/src/components/Mnemonic.js
@@ -23,7 +23,6 @@ const StyledSeedItem = styled.li.attrs((props) => ({
   position: relative;
   text-align: left;
   white-space: pre;
-  white-space: pre;
   width: calc(33.3% - 9px);
 
   &:nth-child(3n + 1) {

--- a/src/components/Mnemonic.js
+++ b/src/components/Mnemonic.js
@@ -1,31 +1,53 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { Grid, Paper } from '@material-ui/core';
-import { makeStyles } from '@material-ui/core/styles';
+import styled from 'styled-components';
 
-const useStyles = makeStyles((theme) => ({
-  mnemonicItem: {
-    margin: '0 auto',
-    padding: theme.spacing(0.5),
-    textAlign: 'center',
-  },
-}));
+const StyledSeedContainer = styled.ol`
+  flex-wrap: wrap;
+  list-style: none;
+  margin: 0;
+  padding: 0 16px;
+`;
 
-const Mnemonic = ({ text }) => {
-  const classes = useStyles();
+const StyledSeedItem = styled.li.attrs((props) => ({
+  data: props.data + 1,
+}))`
+  background: #fff;
+  border-radius: 4px;
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.1);
+  display: inline-block;
+  margin-bottom: 16px;
+  margin-left: 9px;
+  padding: 8px;
+  position: relative;
+  text-align: left;
+  white-space: pre;
+  white-space: pre;
+  width: calc(33.3% - 9px);
 
-  return (
-    <Grid container spacing={2}>
-      {text.split(' ').map((word, index) => {
-        return (
-          <Grid item key={index} xs={3}>
-            <Paper className={classes.mnemonicItem}>{word}</Paper>
-          </Grid>
-        );
-      })}
-    </Grid>
-  );
-};
+  &:nth-child(3n + 1) {
+    margin-left: 0;
+  }
+
+  &:before {
+    content: attr(data);
+    margin-right: 4px;
+    opacity: 0.4;
+  }
+`;
+
+const Mnemonic = ({ text }) => (
+  <StyledSeedContainer>
+    {text.split(' ').map((word, index) => {
+      return (
+        <StyledSeedItem data={index} key={index} xs={3}>
+          {word + ' '}
+        </StyledSeedItem>
+      );
+    })}
+  </StyledSeedContainer>
+);
 
 Mnemonic.propTypes = {
   text: PropTypes.string.isRequired,

--- a/src/components/Mnemonic.js
+++ b/src/components/Mnemonic.js
@@ -40,7 +40,7 @@ const Mnemonic = ({ text }) => (
   <StyledSeedContainer>
     {text.split(' ').map((word, index) => {
       return (
-        <StyledSeedItem data={index} key={index} xs={3}>
+        <StyledSeedItem data={index} key={index}>
           {word + ' '}
         </StyledSeedItem>
       );


### PR DESCRIPTION
### Summary
This adds numbers to the seed phrase, and uses already included styled-components package.

### Details

- In order to allow copying + pasting of values **without** numbers, css-psuedo-elements now reference a `data` prop, which is passed via `styled.li.attrs()`.
- A separate copying + pasting improvement means that there is now only a space between words, removing the line breaks. This now matches the format which importing a seed phrase requires.
- MD's grid has been dropped in favour of a standard CSS grid, to prevent any fighting with MD styles while achieving the prior, and to allow for the list to be semantic (`ol`, `li`).
- The shadows have been tweaked to make them a little less janky :-)

<img src="https://user-images.githubusercontent.com/4670881/100469707-172f2680-30d7-11eb-835a-bf8fc6436b1f.png" width="400" />

