### PR TITLE
[Improvement] Allow mixed whitespace characters in login

### DIFF
--- a/src/views/Login.js
+++ b/src/views/Login.js
@@ -41,7 +41,7 @@ const Login = () => {
     dispatch(showSpinnerOverlay());
 
     try {
-      await dispatch(restoreAccount(seedPhrase.trim()));
+      await dispatch(restoreAccount(parsedPhrase.join(' ')));
 
       dispatch(
         notify({
@@ -69,7 +69,8 @@ const Login = () => {
     dispatch(hideSpinnerOverlay());
   };
 
-  const isValid = seedPhrase.trim().split(' ').length === 24;
+  const parsedPhrase = seedPhrase.trim().split(/\s+/g);
+  const isValid = parsedPhrase.length === 24;
 
   return (
     <Fragment>


### PR DESCRIPTION
This splits the seed phrase by more (grouped) whitespace characters, including spaces, tabs and newlines, before joining them in an acceptable format.