### PR TITLE
Menu in !validated state and user friendly paths

### DIFF
--- a/src/components/Navigation.js
+++ b/src/components/Navigation.js
@@ -1,7 +1,13 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { Link } from 'react-router-dom';
-import { Typography, Drawer, Grid, Button, Box } from '@material-ui/core';
+import {
+  Typography,
+  SwipeableDrawer,
+  Grid,
+  Button,
+  Box,
+} from '@material-ui/core';
 import { generatePath } from 'react-router-dom';
 import { makeStyles } from '@material-ui/core/styles';
 import { useSelector } from 'react-redux';
@@ -39,11 +45,12 @@ import {
 
 const useStyles = makeStyles((theme) => ({
   drawer: {
-    width: theme.custom.components.navigationWidth,
+    // width: theme.custom.components.navigationWidth,
     flexShrink: 0,
   },
   drawerPaper: {
     width: theme.custom.components.navigationWidth,
+    maxWidth: `calc(100% - 48px)`,
     justifyContent: 'space-between',
   },
   navigationHeader: {
@@ -80,27 +87,32 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-const Navigation = ({ isExpanded, ...props }) => {
+const Navigation = ({ onOpen, onClose, open, authorized, verified }) => {
   const classes = useStyles();
 
   return (
-    <Drawer
-      anchor="left"
-      className={classes.drawer}
-      classes={{
-        paper: classes.drawerPaper,
-      }}
-      open={isExpanded}
-      {...props}
+    <SwipeableDrawer
+      classes={{ paper: classes.drawerPaper }}
+      open={open}
+      onClose={onClose}
+      onOpen={onOpen}
     >
-      <NavigationHeader onClick={props.onClick} />
-      <NavigationMain onClick={props.onClick} />
-      <NavigationFooter />
-    </Drawer>
+      <NavigationHeader
+        authorized={authorized}
+        verified={verified}
+        onClick={onClose}
+      />
+      <NavigationMain
+        authorized={authorized}
+        verified={verified}
+        onClick={onClose}
+      />
+      <NavigationFooter authorized={authorized} verified={verified} />
+    </SwipeableDrawer>
   );
 };
 
-const NavigationHeader = ({ onClick }) => {
+const NavigationHeader = ({ onClick, authorized, verified }) => {
   const classes = useStyles();
   const safe = useSelector((state) => state.safe);
 
@@ -111,10 +123,12 @@ const NavigationHeader = ({ onClick }) => {
         to={MY_PROFILE_PATH}
         onClick={onClick}
       >
-        <AvatarWithQR address={safe.currentAccount} />
+        <AvatarWithQR address={safe.currentAccount || safe.pendingAddress} />
         <Box mt={1.5}>
           <Typography variant="h6">
-            <UsernameDisplay address={safe.currentAccount} />
+            <UsernameDisplay
+              address={safe.currentAccount || safe.pendingAddress}
+            />
           </Typography>
         </Box>
       </Link>
@@ -122,7 +136,7 @@ const NavigationHeader = ({ onClick }) => {
   );
 };
 
-const NavigationMain = ({ onClick }) => {
+const NavigationMain = ({ onClick, authorized, verified }) => {
   const classes = useStyles();
 
   return (
@@ -240,16 +254,23 @@ const NavigationExternalLink = ({ children, href }) => {
 };
 
 Navigation.propTypes = {
-  isExpanded: PropTypes.bool.isRequired,
-  onClick: PropTypes.func.isRequired,
+  authorized: PropTypes.bool,
+  onClose: PropTypes.func.isRequired,
+  onOpen: PropTypes.func.isRequired,
+  open: PropTypes.bool.isRequired,
+  verified: PropTypes.bool,
 };
 
 NavigationHeader.propTypes = {
+  authorized: PropTypes.bool,
   onClick: PropTypes.func.isRequired,
+  verified: PropTypes.bool,
 };
 
 NavigationMain.propTypes = {
+  authorized: PropTypes.bool,
   onClick: PropTypes.func.isRequired,
+  verified: PropTypes.bool,
 };
 
 NavigationLink.propTypes = {
@@ -262,4 +283,4 @@ NavigationExternalLink.propTypes = {
   href: PropTypes.string.isRequired,
 };
 
-export default React.memo(Navigation);
+export default Navigation;

--- a/src/components/Navigation.js
+++ b/src/components/Navigation.js
@@ -24,6 +24,7 @@ import {
   SEND_PATH,
   SETTINGS_PATH,
   SHARE_PATH,
+  VALIDATION_SHARE_PATH,
 } from '~/routes';
 import {
   ABOUT_URL,
@@ -139,16 +140,32 @@ const NavigationHeader = ({ onClick, authorized, verified }) => {
 const NavigationMain = ({ onClick, authorized, verified }) => {
   const classes = useStyles();
 
+  if (verified) {
+    return (
+      <Box className={classes.navigationMain} component="main">
+        <NavigationLink to={SHARE_PATH} onClick={onClick}>
+          {translate('Navigation.buttonMyQR')}
+        </NavigationLink>
+        <NavigationLink to={ACTIVITIES_PATH} onClick={onClick}>
+          {translate('Navigation.buttonActivityLog')}
+        </NavigationLink>
+        <NavigationLink to={generatePath(SEND_PATH)} onClick={onClick}>
+          {translate('Navigation.buttonSendCircles')}
+        </NavigationLink>
+        <NavigationLink to={SETTINGS_PATH} onClick={onClick}>
+          {translate('Navigation.buttonAddDevice')}
+        </NavigationLink>
+        <NavigationLink to={SEED_PHRASE_PATH} onClick={onClick}>
+          {translate('Navigation.buttonExportSeedPhrase')}
+        </NavigationLink>
+      </Box>
+    );
+  }
+
   return (
     <Box className={classes.navigationMain} component="main">
-      <NavigationLink to={SHARE_PATH} onClick={onClick}>
+      <NavigationLink to={VALIDATION_SHARE_PATH} onClick={onClick}>
         {translate('Navigation.buttonMyQR')}
-      </NavigationLink>
-      <NavigationLink to={ACTIVITIES_PATH} onClick={onClick}>
-        {translate('Navigation.buttonActivityLog')}
-      </NavigationLink>
-      <NavigationLink to={generatePath(SEND_PATH)} onClick={onClick}>
-        {translate('Navigation.buttonSendCircles')}
       </NavigationLink>
       <NavigationLink to={SETTINGS_PATH} onClick={onClick}>
         {translate('Navigation.buttonAddDevice')}

--- a/src/routes.js
+++ b/src/routes.js
@@ -7,7 +7,6 @@ import Activities from '~/views/Activities';
 import Dashboard from '~/views/Dashboard';
 import Error from '~/views/Error';
 import Login from '~/views/Login';
-import NotFound from '~/views/NotFound';
 import Onboarding from '~/views/Onboarding';
 import Profile from '~/views/Profile';
 import QRGenerator from '~/views/QRGenerator';
@@ -37,8 +36,8 @@ export const MY_PROFILE_PATH = '/profile';
 // Main routes
 export const ACTIVITIES_PATH = '/activities';
 export const DASHBOARD_PATH = '/';
-export const LOGIN_PATH = '/welcome/login';
-export const ONBOARDING_PATH = '/welcome/onboarding';
+export const LOGIN_PATH = '/login';
+export const ONBOARDING_PATH = '/register';
 export const ORGANIZATION_MEMBERS_ADD_PATH = '/organization/members/add';
 export const ORGANIZATION_MEMBERS_PATH = '/organization/members';
 export const ORGANIZATION_PATH = '/organization';
@@ -50,126 +49,9 @@ export const SEND_CONFIRM_PATH = '/send/:address(0x[0-9a-fA-f]{40})';
 export const SEND_PATH = '/send';
 export const SETTINGS_PATH = '/settings';
 export const SHARE_PATH = '/share';
-export const VALIDATION_PATH = '/validation';
-export const VALIDATION_SHARE_PATH = '/validation/share';
-export const WELCOME_PATH = '/welcome';
-
-const SessionContainer = ({
-  component: Component,
-  isAuthorizationRequired = false,
-  isValidationRequired = false,
-  isOrganizationRequired = false,
-}) => {
-  const { app, safe } = useSelector((state) => state);
-  let isValid = true;
-
-  // Check if user has a valid session ..
-  //
-  // 1. Do we have (predicted) Safe address?
-  // 2. Do we have Wallet?
-  if (isAuthorizationRequired && !app.isAuthorized) {
-    isValid = false;
-  }
-
-  if (!isAuthorizationRequired && app.isAuthorized) {
-    isValid = false;
-  }
-
-  // Check if user is validated ...
-  //
-  // 1. Is the Safe deployed (nonce is not set)?
-  // 2. Do we have a Token address (Token contract is deployed)?
-  if (isValidationRequired && isAuthorizationRequired && !app.isValidated) {
-    isValid = false;
-  }
-
-  if (!isValidationRequired && isAuthorizationRequired && app.isValidated) {
-    isValid = false;
-  }
-
-  // Check if user is an organization ..
-  if (isOrganizationRequired && !safe.isOrganization) {
-    isValid = false;
-  }
-
-  if (isValid) {
-    return <Component />;
-  }
-
-  // Redirect to fallback routes ..
-  if (app.isAuthorized) {
-    if (isValidationRequired) {
-      return <Redirect to={VALIDATION_PATH} />;
-    }
-
-    return <Redirect to={DASHBOARD_PATH} />;
-  }
-
-  return <Redirect to={WELCOME_PATH} />;
-};
-
-// Containers for routes with different permissions
-
-const OnboardingRoute = ({ component, path }) => {
-  return (
-    <Route path={path}>
-      <SessionContainer component={component} />
-    </Route>
-  );
-};
-
-const SessionRoute = ({ component, path }) => {
-  return (
-    <Route path={path}>
-      <SessionContainer component={component} isAuthorizationRequired />
-    </Route>
-  );
-};
-
-const TrustedRoute = ({ component, path }) => {
-  return (
-    <Route path={path}>
-      <SessionContainer
-        component={component}
-        isAuthorizationRequired
-        isValidationRequired
-      />
-    </Route>
-  );
-};
-
-const OrganizationRoute = ({ component, path }) => {
-  return (
-    <Route path={path}>
-      <SessionContainer
-        component={component}
-        isAuthorizationRequired
-        isOrganizationRequired
-        isValidationRequired
-      />
-    </Route>
-  );
-};
-
-// Containers for organizations
-
-// @TODO: Removed organizations for now
-// const OnboardingOrganizationContainer = () => {
-//   const safe = useSelector((state) => state.safe);
-//   if (safe.isOrganization) {
-//     return <Redirect to={DASHBOARD_PATH} />;
-//   }
-//   return <OnboardingOrganization />;
-// };
-
-const DashboardContainer = () => {
-  // @TODO: Removed organizations for now
-  // const safe = useSelector((state) => state.safe);
-  // if (safe.isOrganization) {
-  //   return <DashboardOrganization />;
-  // }
-  return <Dashboard />;
-};
+export const VALIDATION_PATH = '/';
+export const VALIDATION_SHARE_PATH = '/share';
+export const WELCOME_PATH = '/';
 
 // Containers for tutorials
 
@@ -240,74 +122,73 @@ const Routes = () => {
     return <ValidationLock />;
   }
 
+  const verified = app.isValidated && app.isAuthorized;
+  const authorized = !app.isValidated && app.isAuthorized;
+
   return (
-    <Switch location={location}>
-      <Route component={Settings} exact path={SETTINGS_PATH} />
-      <OnboardingRoute component={Welcome} exact path={WELCOME_PATH} />
-      <OnboardingRoute
-        component={TutorialOnboardingContainer}
-        exact
-        path={ONBOARDING_PATH}
-      />
-      <OnboardingRoute component={Login} exact path={LOGIN_PATH} />
-      <SessionRoute component={Validation} exact path={VALIDATION_PATH} />
-      <SessionRoute
-        component={ValidationShare}
-        exact
-        path={VALIDATION_SHARE_PATH}
-      />
-      <TrustedRoute component={SendConfirm} exact path={SEND_CONFIRM_PATH} />
-      <TrustedRoute component={Send} exact path={SEND_PATH} />
-      <TrustedRoute component={SeedPhrase} exact path={SEED_PHRASE_PATH} />
-      <TrustedRoute component={Share} exact path={SHARE_PATH} />
-      <TrustedRoute component={Profile} exact path={PROFILE_PATH} />
-      <TrustedRoute component={Activities} exact path={ACTIVITIES_PATH} />
-      <TrustedRoute component={QRGenerator} exact path={QR_GENERATOR_PATH} />
-      <TrustedRoute component={Search} exact path={SEARCH_PATH} />
-      {/* <OrganizationRoute */}
-      {/*   component={OrganizationMembersAdd} */}
-      {/*   exact */}
-      {/*   path={ORGANIZATION_MEMBERS_ADD_PATH} */}
-      {/* /> */}
-      {/* <OrganizationRoute */}
-      {/*   component={OrganizationMembers} */}
-      {/*   exact */}
-      {/*   path={ORGANIZATION_MEMBERS_PATH} */}
-      {/* /> */}
-      {/* <TrustedRoute */}
-      {/*   component={OnboardingOrganizationContainer} */}
-      {/*   exact */}
-      {/*   path={ORGANIZATION_PATH} */}
-      {/* /> */}
-      <TrustedRoute component={DashboardContainer} path={DASHBOARD_PATH} />
-      <Route component={NotFound} />
-    </Switch>
+    <>
+      {verified ? (
+        <Switch location={location}>
+          <Route component={SendConfirm} exact path={SEND_CONFIRM_PATH} />
+          <Route component={Send} exact path={SEND_PATH} />
+          <Route component={Share} exact path={SHARE_PATH} />
+          <Route component={Profile} exact path={PROFILE_PATH} />
+          <Route component={Activities} exact path={ACTIVITIES_PATH} />
+          <Route component={QRGenerator} exact path={QR_GENERATOR_PATH} />
+          <Route component={Search} exact path={SEARCH_PATH} />
+          <Route component={Settings} exact path={SETTINGS_PATH} />
+          <Route component={SeedPhrase} exact path={SEED_PHRASE_PATH} />
+          <Route component={Dashboard} exact path={DASHBOARD_PATH} />
+          <Route path={'*'}>
+            <Redirect to={DASHBOARD_PATH} />
+          </Route>
+        </Switch>
+      ) : authorized ? (
+        <>
+          <Switch location={location}>
+            <Route component={Profile} exact path={PROFILE_PATH} />
+            <Route
+              component={ValidationShare}
+              exact
+              path={VALIDATION_SHARE_PATH}
+            />
+            <Route component={Settings} exact path={SETTINGS_PATH} />
+            <Route component={SeedPhrase} exact path={SEED_PHRASE_PATH} />
+            <Route component={Validation} exact path={VALIDATION_PATH} />
+            <Route path={'*'}>
+              <Redirect to={VALIDATION_PATH} />
+            </Route>
+          </Switch>
+        </>
+      ) : (
+        <Switch location={location}>
+          <Route component={Welcome} exact path={WELCOME_PATH} />
+          <Route
+            component={TutorialOnboardingContainer}
+            exact
+            path={ONBOARDING_PATH}
+          />
+          <Route component={Login} exact path={LOGIN_PATH} />
+          <Route path={'*'}>
+            <Redirect to={WELCOME_PATH} />
+          </Route>
+        </Switch>
+      )}
+    </>
   );
 };
 
-SessionContainer.propTypes = {
-  component: PropTypes.elementType.isRequired,
-  isAuthorizationRequired: PropTypes.bool,
-  isOrganizationRequired: PropTypes.bool,
-  isValidationRequired: PropTypes.bool,
-};
-
-OnboardingRoute.propTypes = {
+Route.propTypes = {
   component: PropTypes.elementType.isRequired,
   path: PropTypes.string.isRequired,
 };
 
-SessionRoute.propTypes = {
+Route.propTypes = {
   component: PropTypes.elementType.isRequired,
   path: PropTypes.string.isRequired,
 };
 
-TrustedRoute.propTypes = {
-  component: PropTypes.elementType.isRequired,
-  path: PropTypes.string.isRequired,
-};
-
-OrganizationRoute.propTypes = {
+Route.propTypes = {
   component: PropTypes.elementType.isRequired,
   path: PropTypes.string.isRequired,
 };

--- a/src/views/Dashboard.js
+++ b/src/views/Dashboard.js
@@ -1,5 +1,4 @@
 import React, { Fragment, useRef, useState } from 'react';
-import clsx from 'clsx';
 import {
   Avatar,
   Box,
@@ -73,9 +72,6 @@ const useStyles = makeStyles((theme) => ({
   headerExpanded: {
     ...transitionExpandedMixin(theme),
   },
-  navigation: {
-    width: theme.custom.components.navigationWidth,
-  },
   view: {
     ...transitionMixin(theme),
   },
@@ -103,7 +99,7 @@ const useStyles = makeStyles((theme) => ({
 const Dashboard = () => {
   const dispatch = useDispatch();
   const classes = useStyles();
-  const [isMenuExpanded, setIsMenuExpanded] = useState(false);
+  const [isOpen, setIsOpen] = useState(false);
   const safe = useSelector((state) => state.safe);
 
   useUpdateLoop(async () => {
@@ -112,20 +108,12 @@ const Dashboard = () => {
   });
 
   const handleMenuToggle = () => {
-    setIsMenuExpanded(!isMenuExpanded);
-  };
-
-  const handleMenuClick = () => {
-    setIsMenuExpanded(false);
+    setIsOpen(!isOpen);
   };
 
   return (
     <Fragment>
-      <Header
-        className={clsx(classes.header, {
-          [classes.headerExpanded]: isMenuExpanded,
-        })}
-      >
+      <Header className={classes.header}>
         <IconButton aria-label="Menu" edge="start" onClick={handleMenuToggle}>
           <IconMenu />
         </IconButton>
@@ -137,15 +125,13 @@ const Dashboard = () => {
         <DashboardActivityIcon />
       </Header>
       <Navigation
-        className={classes.navigation}
-        isExpanded={isMenuExpanded}
-        onClick={handleMenuClick}
+        authorized
+        open={isOpen}
+        verified
+        onClose={handleMenuToggle}
+        onOpen={handleMenuToggle}
       />
-      <View
-        className={clsx(classes.view, {
-          [classes.viewExpanded]: isMenuExpanded,
-        })}
-      >
+      <View className={classes.view}>
         <Container maxWidth="sm">
           <BalanceDisplay />
           <AppNote />
@@ -155,12 +141,7 @@ const Dashboard = () => {
           <LastInteractions />
         </Container>
       </View>
-      <ButtonSend
-        className={clsx(classes.fabSend, {
-          [classes.fabSendExpanded]: isMenuExpanded,
-        })}
-        to={generatePath(SEND_PATH)}
-      />
+      <ButtonSend className={classes.fabSend} to={generatePath(SEND_PATH)} />
       <Drawer />
     </Fragment>
   );

--- a/src/views/DashboardOrganization.js
+++ b/src/views/DashboardOrganization.js
@@ -1,5 +1,4 @@
 import React, { Fragment, useState } from 'react';
-import clsx from 'clsx';
 import { Container, IconButton } from '@material-ui/core';
 import { Link, generatePath } from 'react-router-dom';
 import { makeStyles } from '@material-ui/core/styles';
@@ -74,24 +73,15 @@ const useStyles = makeStyles((theme) => ({
 
 const DashboardOrganization = () => {
   const classes = useStyles();
-  const [isMenuExpanded, setIsMenuExpanded] = useState(false);
   const safe = useSelector((state) => state.safe);
-
+  const [isOpen, setIsOpen] = useState(false);
   const handleMenuToggle = () => {
-    setIsMenuExpanded(!isMenuExpanded);
-  };
-
-  const handleMenuClick = () => {
-    setIsMenuExpanded(false);
+    setIsOpen(!isOpen);
   };
 
   return (
     <Fragment>
-      <Header
-        className={clsx(classes.header, {
-          [classes.headerExpanded]: isMenuExpanded,
-        })}
-      >
+      <Header className={classes.header}>
         <IconButton aria-label="Menu" edge="start" onClick={handleMenuToggle}>
           <IconMenu />
         </IconButton>
@@ -110,15 +100,13 @@ const DashboardOrganization = () => {
         </IconButton>
       </Header>
       <Navigation
-        className={classes.navigation}
-        isExpanded={isMenuExpanded}
-        onClick={handleMenuClick}
+        authorized
+        open={isOpen}
+        verified
+        onClose={handleMenuToggle}
+        onOpen={handleMenuToggle}
       />
-      <View
-        className={clsx(classes.view, {
-          [classes.viewExpanded]: isMenuExpanded,
-        })}
-      >
+      <View className={classes.view}>
         <Container maxWidth="sm">
           <BalanceDisplayOrganization />
           <AppNote />
@@ -127,20 +115,13 @@ const DashboardOrganization = () => {
       </View>
       <ButtonAction
         aria-label="Generate QR"
-        className={clsx(classes.fabQR, {
-          [classes.fabExpanded]: isMenuExpanded,
-        })}
+        className={classes.fabQR}
         component={Link}
         to={QR_GENERATOR_PATH}
       >
         <IconQRLarge fontSize="large" />
       </ButtonAction>
-      <ButtonSend
-        className={clsx(classes.fab, {
-          [classes.fabExpanded]: isMenuExpanded,
-        })}
-        to={generatePath(SEND_PATH)}
-      />
+      <ButtonSend className={classes.fab} to={generatePath(SEND_PATH)} />
       <Drawer />
     </Fragment>
   );

--- a/src/views/Profile.js
+++ b/src/views/Profile.js
@@ -119,6 +119,7 @@ const Profile = () => {
               badgeContent={
                 <ProfileTrustButton
                   address={address}
+                  deploymentStatus={deploymentStatus}
                   trustStatus={trustStatus}
                 />
               }
@@ -344,13 +345,21 @@ const ProfileSendButton = ({ address, deploymentStatus }) => {
   );
 };
 
-const ProfileTrustButton = ({ address, trustStatus }) => {
+const ProfileTrustButton = ({ address, trustStatus, deploymentStatus }) => {
   const classes = useStyles();
   const safe = useSelector((state) => state.safe);
 
   const { isOrganization, isReady } = useIsOrganization(address);
 
-  const isDisabled = safe.currentAccount === address;
+  // Check against these three cases where we can't trust
+  //
+  // a) We look at our own profile
+  // b) Our Safe is not deployed yet
+  // c) The profiles Safe is not deployed yet
+  const isDisabled =
+    safe.currentAccount === address ||
+    safe.pendingNonce !== null ||
+    (!deploymentStatus.isDeployed && !isOrganization);
 
   const [isTrustConfirmOpen, setIsTrustConfirmOpen] = useState(false);
   const [isRevokeTrustOpen, setIsRevokeTrustOpen] = useState(false);
@@ -459,6 +468,7 @@ ProfileSendButton.propTypes = {
 ProfileTrustButton.propTypes = {
   address: PropTypes.string.isRequired,
   trustStatus: PropTypes.object.isRequired,
+  deploymentStatus: PropTypes.object.isRequired,
 };
 
 export default Profile;

--- a/src/views/Profile.js
+++ b/src/views/Profile.js
@@ -354,12 +354,8 @@ const ProfileTrustButton = ({ address, trustStatus, deploymentStatus }) => {
   // Check against these three cases where we can't trust
   //
   // a) We look at our own profile
-  // b) Our Safe is not deployed yet
-  // c) The profiles Safe is not deployed yet
-  const isDisabled =
-    safe.currentAccount === address ||
-    safe.pendingNonce !== null ||
-    (!deploymentStatus.isDeployed && !isOrganization);
+  const isDisabled = (safe.pendingAddress || safe.currentAccount) === address;
+  console.log(safe.pendingAddress || safe.currentAccount);
 
   const [isTrustConfirmOpen, setIsTrustConfirmOpen] = useState(false);
   const [isRevokeTrustOpen, setIsRevokeTrustOpen] = useState(false);
@@ -467,8 +463,8 @@ ProfileSendButton.propTypes = {
 
 ProfileTrustButton.propTypes = {
   address: PropTypes.string.isRequired,
-  trustStatus: PropTypes.object.isRequired,
   deploymentStatus: PropTypes.object.isRequired,
+  trustStatus: PropTypes.object.isRequired,
 };
 
 export default Profile;

--- a/src/views/Validation.js
+++ b/src/views/Validation.js
@@ -1,10 +1,17 @@
-import React, { Fragment } from 'react';
-import { Avatar, Box, Container, Tooltip, Typography } from '@material-ui/core';
-import { Link } from 'react-router-dom';
+import React, { Fragment, useState } from 'react';
+import {
+  Avatar,
+  Box,
+  Container,
+  Tooltip,
+  Typography,
+  IconButton,
+} from '@material-ui/core';
+
 import { makeStyles } from '@material-ui/core/styles';
 import { useSelector, useDispatch } from 'react-redux';
 
-import AvatarWithQR from '~/components/AvatarWithQR';
+import Navigation from '~/components/Navigation';
 import BalanceDisplay from '~/components/BalanceDisplay';
 import Button from '~/components/Button';
 import CenteredHeading from '~/components/CenteredHeading';
@@ -15,7 +22,7 @@ import UsernameDisplay from '~/components/UsernameDisplay';
 import ValidationStatus from '~/components/ValidationStatus';
 import View from '~/components/View';
 import translate from '~/services/locale';
-import { IconCheck } from '~/styles/icons';
+import { IconMenu, IconCheck } from '~/styles/icons';
 import { NEEDED_TRUST_CONNECTIONS } from '~/utils/constants';
 import { VALIDATION_SHARE_PATH } from '~/routes';
 import { checkTrustState } from '~/store/trust/actions';
@@ -35,6 +42,7 @@ const Validation = () => {
   const classes = useStyles();
 
   const { trust, safe, token } = useSelector((state) => state);
+  const [isOpen, setIsOpen] = useState(false);
 
   useUpdateLoop(async () => {
     await dispatch(checkTrustState());
@@ -48,12 +56,16 @@ const Validation = () => {
   const isDeploymentReady =
     safe.pendingIsFunded || token.isFunded || trust.isTrusted;
 
+  const handleMenuToggle = () => {
+    setIsOpen(!isOpen);
+  };
+
   return (
     <Fragment>
       <Header>
-        <Link to={VALIDATION_SHARE_PATH}>
-          <AvatarWithQR address={safe.pendingAddress} />
-        </Link>
+        <IconButton aria-label="Menu" edge="start" onClick={handleMenuToggle}>
+          <IconMenu />
+        </IconButton>
         <CenteredHeading>
           <UsernameDisplay address={safe.pendingAddress} />
         </CenteredHeading>
@@ -89,6 +101,12 @@ const Validation = () => {
           </Box>
         )}
       </Footer>
+      <Navigation
+        authorized
+        open={isOpen}
+        onClose={handleMenuToggle}
+        onOpen={handleMenuToggle}
+      />
     </Fragment>
   );
 };


### PR DESCRIPTION
- Routes have been updated to use switches, generated depending on the user's current authorization state.
- - `authorized && validated` uses a full functionality switch
- - `authorized && !validated` uses a limited, pending state switch
- - All others go to a public switch
- Redirects go to homepages based on the authorization state, meaning that the `NotFound` component is now not in use.
- Navigation now displays in `!validated` accounts.
-  - The menu functionality is limited, only allowing the user to view their seed phrase, log out, and access the menu footer.
- Paths have been updated to be much flatter and user friendly:
- - `/validate, /welcome` are now `/`
- - `/welcome/onboarding` is now `register`
- - `/welcome/login` is now `/login`
- - `/validate/share` is now `/share`
- User can also view other profiles when in the `authorized && !validated` state
- - Trusting a profile is disabled unless the user is validated

This closes #147 as a lot of the routing updates are done more elegantly here.