### PR TITLE
Allow generic user notifications

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,8 +28,7 @@ SUBGRAPH_NAME=CirclesUBI/circles-subgraph
 SENTRY_DSN_URL=
 
 # Show app notes to users
-STAGING_NOTIFICATION=
-EOL_NOTIFICATION=
+USER_NOTIFICATION=
 
 # LocalStorage namespace
 # @WARNING: Changing this will reset all users accounts as they will loose

--- a/locales/en.json
+++ b/locales/en.json
@@ -334,9 +334,5 @@
     "linkContactUs": "Contact us",
     "linkFAQ": "FAQ",
     "linkPrivacyLegal": "Privacy + Legal"
-  },
-  "default": {
-    "bodyEOLNotification": "We're launching Circles officially on 16.10. on the xDai network! Since this app is currently running on a test network your profile will be shut off on that same day. You will need to create a new profile for the official Circles network.",
-    "bodyStagingNotification": "Please note that you're currently using Circles in a test network which is used by developers to experiment with the system. This means that errors can occur as we're experimenting with new unstable features, your Circles can only be used for testing and you can lose your profile, tokens and data anytime."
   }
 }

--- a/src/components/AppNote.js
+++ b/src/components/AppNote.js
@@ -2,16 +2,11 @@ import React from 'react';
 import { Box } from '@material-ui/core';
 
 import HumbleAlert from '~/components/HumbleAlert';
-import translate from '~/services/locale';
 
 const AppNote = () => {
-  return process.env.STAGING_NOTIFICATION || process.env.EOL_NOTIFICATION ? (
+  return process.env.USER_NOTIFICATION ? (
     <Box my={2}>
-      <HumbleAlert>
-        {process.env.STAGING_NOTIFICATION
-          ? translate('default.bodyStagingNotification')
-          : translate('default.bodyEOLNotification')}
-      </HumbleAlert>
+      <HumbleAlert>{process.env.USER_NOTIFICATION}</HumbleAlert>
     </Box>
   ) : null;
 };

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -25,11 +25,10 @@ const CONFIG_KEYS = [
 ];
 
 const CONFIG_KEYS_OPTIONAL = [
-  'EOL_NOTIFICATION',
+  'USER_NOTIFICATION',
   'EXPLORER_URL',
   'ISSUANCE_RATE_MONTH',
   'SENTRY_DSN_URL',
-  'STAGING_NOTIFICATION',
   'STORAGE_NAMESPACE',
 ];
 
@@ -153,11 +152,7 @@ export default () => {
           : {
               collapseWhitespace: true,
             },
-        title:
-          PAGE_TITLE +
-          (process.env.STAGING_NOTIFICATION || process.env.EOL_NOTIFICATION
-            ? ' [TEST NETWORK]'
-            : ''),
+        title: PAGE_TITLE,
         favicon: getPath(`${PATH_ASSETS}/favicon.ico`),
         template: getPath(`${PATH_SRC}/index.html`),
       }),


### PR DESCRIPTION
Introduces an optional environment variable which can be used to set individual and global user notifications which will be displayed in the app.

We can use this for now as a quick solution to inform the users about current problems / outages as we experience right now for example with the xDai network.

Also, this PR removes the old hard-coded notifications about test networks and the pre-release version as they are not used anymore.