### PR TITLE
Recover from invalid state when restoring undeployed account

### DIFF
--- a/src/store/safe/actions.js
+++ b/src/store/safe/actions.js
@@ -97,7 +97,9 @@ export function recreateUndeployedSafe() {
       // but not deployed yet).
       const status = await core.safe.getSafeStatus(pendingAddress);
       if (!status.isCreated) {
-        throw new Error('Safe is not known to system');
+        // This Safe is not know to the relayer (something must have went wrong
+        // there), register it!
+        await core.safe.prepareDeploy(pendingNonce);
       }
 
       dispatch({


### PR DESCRIPTION
Some undeployed accounts try to recover but fail since the relayer does not know about them. Usually the relayer should know about these accounts but due to connectivity problems, internal relayer errors from the past etc. some user data is missing.

This PR fixes this problem by automatically "recovering" from this invalid state by simply registering that undeployed account in the Relayer.

Closes: https://github.com/CirclesUBI/circles-myxogastria/issues/165