### PR TITLE
Retry request logic when failure occurred

### DIFF
--- a/src/store/onboarding/actions.js
+++ b/src/store/onboarding/actions.js
@@ -97,9 +97,10 @@ export function createNewOrganization(
           return core.organization.deploy(safeAddress);
         },
         () => {
-          return isOrganization(safeAddress);
+          return core.organization.isOrganization(safeAddress);
         },
       );
+      await isOrganization(safeAddress);
 
       // Prefund the organization with Tokens from the user
       await core.organization.prefund(

--- a/src/store/safe/actions.js
+++ b/src/store/safe/actions.js
@@ -275,9 +275,14 @@ export function deploySafeForOrganization(safeAddress) {
     });
 
     try {
-      await core.safe.deployForOrganization(safeAddress);
-      await isDeployed(safeAddress);
-
+      await waitAndRetryOnFail(
+        () => {
+          return core.safe.deployForOrganization(safeAddress);
+        },
+        async () => {
+          return (await web3.eth.getCode(safeAddress)) !== '0x';
+        },
+      );
       dispatch({
         type: ActionTypes.SAFE_DEPLOY_SUCCESS,
       });
@@ -285,7 +290,6 @@ export function deploySafeForOrganization(safeAddress) {
       dispatch({
         type: ActionTypes.SAFE_DEPLOY_ERROR,
       });
-
       throw error;
     }
   };

--- a/src/store/safe/actions.js
+++ b/src/store/safe/actions.js
@@ -16,7 +16,7 @@ import {
 } from '~/services/safe';
 import web3 from '~/services/web3';
 import ActionTypes from '~/store/safe/types';
-import isDeployed, { waitAndRetryOnFail } from '~/utils/stateChecks';
+import { isDeployed, waitAndRetryOnFail } from '~/utils/stateChecks';
 
 export function initializeSafe() {
   return async (dispatch) => {

--- a/src/utils/stateChecks.js
+++ b/src/utils/stateChecks.js
@@ -61,7 +61,13 @@ export async function loop(
   }
 }
 
-// This helper method repeats calling a request when it fails
+// This helper method repeats calling a request when it fails or when a
+// condition was not reached after some attempts.
+//
+// Use this method if you want to make a crucial request for creating or
+// updating data somewhere. When this request fails, for example because of
+// networking issues or server outage, this helper method will try to repeat
+// the request for you until it succeeded.
 export async function waitAndRetryOnFail(
   requestFn,
   loopFn,

--- a/src/utils/stateChecks.js
+++ b/src/utils/stateChecks.js
@@ -103,7 +103,7 @@ export async function waitAndRetryOnFail(
   }
 }
 
-export default async function isDeployed(address) {
+export async function isDeployed(address) {
   await loop(
     () => {
       return web3.eth.getCode(address);

--- a/src/utils/stateChecks.js
+++ b/src/utils/stateChecks.js
@@ -1,91 +1,105 @@
 import core from '~/services/core';
 import web3 from '~/services/web3';
 import { ZERO_ADDRESS } from '~/utils/constants';
-import logError from '~/utils/debug';
 
-const LOOP_INTERVAL = 6000;
-const REQUEST_INTERVAL = 8000;
-const MAX_ATTEMPTS = 20;
-const MAX_ATTEMPTS_RETRY_ON_FAIL = 3;
+// Wait ms before checking condition again
+const LOOP_INTERVAL_DEFAULT = 6000;
 
-async function wait(ms) {
-  setTimeout(() => {}, ms);
+// Times condition is checked before its considered a fail
+const MAX_ATTEMPTS_DEFAULT = 20;
+
+// Times the method will repeat the request after an error or condition failure
+const RETRIES_ON_FAIL_DEFAULT = 3;
+
+// When a request fails wait a few ms before we do it again
+const WAIT_AFTER_FAIL_DEFAULT = 5000;
+
+// Error message used to indicate failed condition check
+const TRIED_TOO_MANY_TIMES = 'Tried too many times waiting for condition.';
+
+// Helper method to wait for a few milliseconds before we move on
+export async function wait(ms) {
+  await setTimeout(() => {}, ms);
 }
 
-async function loop(request, condition) {
-  let attempt = 0;
-  let conditionResult = false;
-  while (conditionResult === false && attempt <= MAX_ATTEMPTS) {
-    try {
+// This helper method resolves as soon as a certain condition was reached and
+// throws an exception when too many attempts were made waiting for it.
+//
+// The `conditionFn` function checks the result of the `requestFn` function.
+// For each attempt a request is made and the condition is checked.
+//
+// Use this if you're waiting for a condition to arrive before you move on with
+// other tasks. Do not use this when the used request is somehow writing /
+// updating data, this should only serve for reading state and waiting until it
+// arrives at the given condition.
+export async function loop(
+  requestFn,
+  conditionFn,
+  {
+    maxAttempts = MAX_ATTEMPTS_DEFAULT,
+    loopInterval = LOOP_INTERVAL_DEFAULT,
+  } = {},
+) {
+  // Count all attempts checking for the condition to arrive
+  let attempt = 1;
+
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    // Get response of request and check for its condition
+    const response = await requestFn();
+
+    if (conditionFn(response)) {
+      return response;
+    } else if (attempt >= maxAttempts) {
+      throw new Error(TRIED_TOO_MANY_TIMES);
+    } else {
       attempt += 1;
-      alert('loop - request loop ' + attempt);
-      const response = await request();
-      if (condition(response) === true) {
-        return response;
-      }
-      await wait(LOOP_INTERVAL);
-    } catch (error) {
-      conditionResult = false;
-      logError(error);
-      throw new Error('Tried too many times waiting for condition.');
     }
+
+    // Condition did not arrive yet, lets wait and try again ..
+    await wait(loopInterval);
   }
-  if (attempt >= MAX_ATTEMPTS) {
-    throw Error('Tried too many times waiting for condition.');
-  }
-
-  // return new Promise((resolve, reject) => {
-  //   let attempt = 0;
-
-  //   const interval = setInterval(async () => {
-  //     try {
-  //       const response = await request();
-  //       attempt += 1;
-
-  //       if (condition(response)) {
-  //         clearInterval(interval);
-  //         resolve(response);
-  //       } else if (attempt > MAX_ATTEMPTS) {
-  //         throw new Error(msg);
-  //       }
-  //     } catch (error) {
-  //       clearInterval(interval);
-  //       reject(error);
-  //     }
-  //   }, LOOP_INTERVAL);
-  // });
 }
 
-export async function waitAndRetryOnFail(request, condition) {
-  let attempt = 0;
-  let conditionAttempt = 0;
-  let conditionResult = false;
-  while (conditionResult === false && attempt <= MAX_ATTEMPTS_RETRY_ON_FAIL) {
+// This helper method repeats calling a request when it fails
+export async function waitAndRetryOnFail(
+  requestFn,
+  loopFn,
+  {
+    maxAttemptsOnFail = RETRIES_ON_FAIL_DEFAULT,
+    waitAfterFail = WAIT_AFTER_FAIL_DEFAULT,
+  } = {},
+) {
+  // Count all attempts to retry when something failed
+  let attempt = 1;
+
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
     try {
-      attempt += 1;
-      alert('retry request loop ' + attempt);
-      const response = await request();
-      conditionAttempt = 0;
-      while (conditionResult === false && conditionAttempt <= MAX_ATTEMPTS) {
-        conditionAttempt += 1;
-        alert('condition loop ' + conditionAttempt);
-        conditionResult = await condition();
-        alert(conditionResult);
-        if (conditionResult === true) {
-          return response;
-        }
-        await wait(LOOP_INTERVAL);
-      }
+      // Make request and wait for response
+      const response = await requestFn();
+
+      // Wait for a few seconds until our condition arrives
+      await loopFn();
+
+      // Finish when request was successful and condition arrived!
+      return response;
     } catch (error) {
-      conditionResult = false;
-      logError(error);
+      // Something went wrong, either the condition did not arrive or the
+      // request failed
+      if (attempt >= maxAttemptsOnFail) {
+        // We tried too often, propagate error and stop here
+        throw error;
+      }
+
+      // Wait when request failed to prevent calling the request too fast again
+      if (error.message !== TRIED_TOO_MANY_TIMES) {
+        await wait(waitAfterFail);
+      }
+
+      // Lets try again ..
+      attempt += 1;
     }
-    await wait(REQUEST_INTERVAL);
-  }
-  if (attempt >= MAX_ATTEMPTS_RETRY_ON_FAIL) {
-    throw Error(
-      'Tried too many times reattempting the request. We may be experiencing networking problems.',
-    );
   }
 }
 

--- a/src/utils/stateChecks.js
+++ b/src/utils/stateChecks.js
@@ -4,49 +4,85 @@ import { ZERO_ADDRESS } from '~/utils/constants';
 import logError from '~/utils/debug';
 
 const LOOP_INTERVAL = 6000;
+const REQUEST_INTERVAL = 8000;
 const MAX_ATTEMPTS = 20;
-const MAX_ATTEMPTS_RETRY_ON_FAIL = 6;
+const MAX_ATTEMPTS_RETRY_ON_FAIL = 3;
+
+async function wait(ms) {
+  setTimeout(() => {}, ms);
+}
 
 async function loop(request, condition) {
-  return new Promise((resolve, reject) => {
-    let attempt = 0;
-
-    const interval = setInterval(async () => {
-      try {
-        const response = await request();
-        attempt += 1;
-
-        if (condition(response)) {
-          clearInterval(interval);
-          resolve(response);
-        } else if (attempt > MAX_ATTEMPTS) {
-          throw new Error('Tried too many times waiting for condition');
-        }
-      } catch (error) {
-        clearInterval(interval);
-        reject(error);
+  let attempt = 0;
+  let conditionResult = false;
+  while (conditionResult === false && attempt <= MAX_ATTEMPTS) {
+    try {
+      attempt += 1;
+      alert('loop - request loop ' + attempt);
+      const response = await request();
+      if (condition(response) === true) {
+        return response;
       }
-    }, LOOP_INTERVAL);
-  });
+      await wait(LOOP_INTERVAL);
+    } catch (error) {
+      conditionResult = false;
+      logError(error);
+      throw new Error('Tried too many times waiting for condition.');
+    }
+  }
+  if (attempt >= MAX_ATTEMPTS) {
+    throw Error('Tried too many times waiting for condition.');
+  }
+
+  // return new Promise((resolve, reject) => {
+  //   let attempt = 0;
+
+  //   const interval = setInterval(async () => {
+  //     try {
+  //       const response = await request();
+  //       attempt += 1;
+
+  //       if (condition(response)) {
+  //         clearInterval(interval);
+  //         resolve(response);
+  //       } else if (attempt > MAX_ATTEMPTS) {
+  //         throw new Error(msg);
+  //       }
+  //     } catch (error) {
+  //       clearInterval(interval);
+  //       reject(error);
+  //     }
+  //   }, LOOP_INTERVAL);
+  // });
 }
 
 export async function waitAndRetryOnFail(request, condition) {
   let attempt = 0;
+  let conditionAttempt = 0;
   let conditionResult = false;
   while (conditionResult === false && attempt <= MAX_ATTEMPTS_RETRY_ON_FAIL) {
     try {
       attempt += 1;
+      alert('retry request loop ' + attempt);
       const response = await request();
-      conditionResult = await condition();
-      if (conditionResult === true) {
-        return response;
+      conditionAttempt = 0;
+      while (conditionResult === false && conditionAttempt <= MAX_ATTEMPTS) {
+        conditionAttempt += 1;
+        alert('condition loop ' + conditionAttempt);
+        conditionResult = await condition();
+        alert(conditionResult);
+        if (conditionResult === true) {
+          return response;
+        }
+        await wait(LOOP_INTERVAL);
       }
     } catch (error) {
       conditionResult = false;
       logError(error);
     }
+    await wait(REQUEST_INTERVAL);
   }
-  if (attempt === MAX_ATTEMPTS_RETRY_ON_FAIL) {
+  if (attempt >= MAX_ATTEMPTS_RETRY_ON_FAIL) {
     throw Error(
       'Tried too many times reattempting the request. We may be experiencing networking problems.',
     );

--- a/src/utils/stateChecks.js
+++ b/src/utils/stateChecks.js
@@ -19,7 +19,7 @@ const TRIED_TOO_MANY_TIMES = 'Tried too many times waiting for condition.';
 
 // Helper method to wait for a few milliseconds before we move on
 export async function wait(ms) {
-  await setTimeout(() => {}, ms);
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 // This helper method resolves as soon as a certain condition was reached and

--- a/test/stateChecks.test.js
+++ b/test/stateChecks.test.js
@@ -175,9 +175,7 @@ describe('stateChecks Utils', () => {
 
       await expect(async () => {
         await waitAndRetryOnFail(
-          () => {
-            return mocks.requestFailed();
-          },
+          mocks.requestFailed,
           () => {
             // The condition is always successful, this time we're checking a
             // failed request
@@ -185,6 +183,7 @@ describe('stateChecks Utils', () => {
           },
           {
             maxAttemptsOnFail: 3,
+            waitAfterFail: 100,
           },
         );
       }).rejects.toThrow(RESULT_ERROR);

--- a/test/stateChecks.test.js
+++ b/test/stateChecks.test.js
@@ -1,0 +1,195 @@
+import { loop, wait, waitAndRetryOnFail } from '~/utils/stateChecks';
+
+const CONDITION_RESULT_SUCCESS = 'success';
+const CONDITION_RESULT_FAILED = 'failed';
+const RESULT_ERROR = 'Something failed ...';
+
+describe('stateChecks Utils', () => {
+  let mocks;
+  let attempt;
+
+  beforeAll(() => {
+    mocks = {
+      // Mock any successful request waiting for x milliseconds, returning any
+      // result which can be checked
+      request: async (waitMs = 50, result = CONDITION_RESULT_SUCCESS) => {
+        await wait(waitMs);
+        return result;
+      },
+      // Mock any failed request waiting for x milliseconds, throwing an
+      // exception
+      requestFailed: async (waitMs = 50, message = RESULT_ERROR) => {
+        await wait(waitMs);
+        throw new Error(message);
+      },
+      conditionRequest: async (waitMs = 50, successAfter = 5) => {
+        await wait(waitMs);
+        attempt += 1;
+
+        if (attempt >= successAfter) {
+          return CONDITION_RESULT_SUCCESS;
+        } else {
+          return CONDITION_RESULT_FAILED;
+        }
+      },
+      // Check an incoming result and compare it with a condition
+      condition: (result, condition = CONDITION_RESULT_SUCCESS) => {
+        return result === condition;
+      },
+    };
+  });
+
+  beforeEach(() => {
+    attempt = 0;
+    jest.clearAllMocks();
+  });
+
+  describe('loop', () => {
+    it('should return the result of the request when successful', async () => {
+      const spyRequest = jest.spyOn(mocks, 'request');
+      const spyCondition = jest.spyOn(mocks, 'condition');
+
+      const response = await loop(
+        () => {
+          return mocks.request();
+        },
+        (result) => {
+          return mocks.condition(result);
+        },
+      );
+
+      expect(spyRequest).toHaveBeenCalledTimes(1);
+      expect(spyCondition).toHaveBeenCalledTimes(1);
+      expect(response).toBe(CONDITION_RESULT_SUCCESS);
+    });
+
+    it('should throw an exception when trying too many times', async () => {
+      const spyRequest = jest.spyOn(mocks, 'request');
+      const spyCondition = jest.spyOn(mocks, 'condition');
+
+      await expect(async () => {
+        await loop(
+          () => {
+            return mocks.request(50, CONDITION_RESULT_FAILED);
+          },
+          (result) => {
+            return mocks.condition(result);
+          },
+          {
+            maxAttempts: 2,
+            loopInterval: 100,
+          },
+        );
+      }).rejects.toThrow('Tried too many times waiting for condition.');
+
+      expect(spyRequest).toHaveBeenCalledTimes(2);
+      expect(spyCondition).toHaveBeenCalledTimes(2);
+    });
+
+    it('should propagate exception when request failed', async () => {
+      await expect(async () => {
+        await loop(
+          () => {
+            return mocks.requestFailed();
+          },
+          (result) => {
+            return mocks.condition(result);
+          },
+        );
+      }).rejects.toThrow(RESULT_ERROR);
+    });
+  });
+
+  describe('waitAndRetryOnFail', () => {
+    it('should return the result of the request when successful', async () => {
+      const spyRequest = jest.spyOn(mocks, 'request');
+      const spyConditionRequest = jest.spyOn(mocks, 'conditionRequest');
+      const spyConditionCheck = jest.spyOn(mocks, 'condition');
+
+      const response = await waitAndRetryOnFail(
+        () => {
+          return mocks.request();
+        },
+        async () => {
+          await loop(
+            () => {
+              return mocks.conditionRequest(50, 2);
+            },
+            (result) => {
+              return mocks.condition(result);
+            },
+            {
+              maxAttempts: 10,
+              loopInterval: 75,
+            },
+          );
+        },
+        {
+          maxAttemptsOnFail: 3,
+        },
+      );
+
+      expect(spyRequest).toHaveBeenCalledTimes(1);
+      expect(spyConditionRequest).toHaveBeenCalledTimes(2);
+      expect(spyConditionCheck).toHaveBeenCalledTimes(2);
+      expect(response).toBe(CONDITION_RESULT_SUCCESS);
+    });
+
+    it('should throw an exception when condition was not met after some attempts', async () => {
+      const spyRequest = jest.spyOn(mocks, 'request');
+      const spyConditionRequest = jest.spyOn(mocks, 'conditionRequest');
+      const spyConditionCheck = jest.spyOn(mocks, 'condition');
+
+      await expect(async () => {
+        await waitAndRetryOnFail(
+          () => {
+            return mocks.request();
+          },
+          async () => {
+            await loop(
+              () => {
+                return mocks.conditionRequest(50, 100);
+              },
+              (result) => {
+                return mocks.condition(result);
+              },
+              {
+                maxAttempts: 5,
+                loopInterval: 75,
+              },
+            );
+          },
+          {
+            maxAttemptsOnFail: 3,
+          },
+        );
+      }).rejects.toThrow('Tried too many times waiting for condition.');
+
+      expect(spyRequest).toHaveBeenCalledTimes(3);
+      expect(spyConditionRequest).toHaveBeenCalledTimes(15);
+      expect(spyConditionCheck).toHaveBeenCalledTimes(15);
+    });
+
+    it('should propagate the error when request failed after all attempts', async () => {
+      const spyRequestFailed = jest.spyOn(mocks, 'requestFailed');
+
+      await expect(async () => {
+        await waitAndRetryOnFail(
+          () => {
+            return mocks.requestFailed();
+          },
+          async () => {
+            // The condition is always successful, this time we're checking a
+            // failed request
+            return true;
+          },
+          {
+            maxAttemptsOnFail: 3,
+          },
+        );
+      }).rejects.toThrow(RESULT_ERROR);
+
+      expect(spyRequestFailed).toHaveBeenCalledTimes(3);
+    });
+  });
+});

--- a/test/stateChecks.test.js
+++ b/test/stateChecks.test.js
@@ -12,18 +12,18 @@ describe('stateChecks Utils', () => {
     mocks = {
       // Mock any successful request waiting for x milliseconds, returning any
       // result which can be checked
-      request: async (waitMs = 50, result = CONDITION_RESULT_SUCCESS) => {
-        await wait(waitMs);
+      request: async (result = CONDITION_RESULT_SUCCESS) => {
+        await wait(50);
         return result;
       },
       // Mock any failed request waiting for x milliseconds, throwing an
       // exception
-      requestFailed: async (waitMs = 50, message = RESULT_ERROR) => {
-        await wait(waitMs);
+      requestFailed: async (message = RESULT_ERROR) => {
+        await wait(50);
         throw new Error(message);
       },
-      conditionRequest: async (waitMs = 50, successAfter = 5) => {
-        await wait(waitMs);
+      conditionRequest: async (successAfter = 5) => {
+        await wait(50);
         attempt += 1;
 
         if (attempt >= successAfter) {
@@ -70,7 +70,7 @@ describe('stateChecks Utils', () => {
       await expect(async () => {
         await loop(
           () => {
-            return mocks.request(50, CONDITION_RESULT_FAILED);
+            return mocks.request(CONDITION_RESULT_FAILED);
           },
           (result) => {
             return mocks.condition(result);
@@ -113,7 +113,7 @@ describe('stateChecks Utils', () => {
         async () => {
           await loop(
             () => {
-              return mocks.conditionRequest(50, 2);
+              return mocks.conditionRequest(2);
             },
             (result) => {
               return mocks.condition(result);
@@ -148,7 +148,7 @@ describe('stateChecks Utils', () => {
           async () => {
             await loop(
               () => {
-                return mocks.conditionRequest(50, 100);
+                return mocks.conditionRequest(100);
               },
               (result) => {
                 return mocks.condition(result);
@@ -178,7 +178,7 @@ describe('stateChecks Utils', () => {
           () => {
             return mocks.requestFailed();
           },
-          async () => {
+          () => {
             // The condition is always successful, this time we're checking a
             // failed request
             return true;


### PR DESCRIPTION
The retry function was developed in this PR: https://github.com/CirclesUBI/circles-myxogastria/pull/195
The implementation was incomplete before because the Errors were not propagating in the retry loop. This is fixed now. 

Related issue: https://github.com/CirclesUBI/circles-myxogastria/issues/207 and #216 