### PR TITLE
The loading symbol doesn't disappear even after the maximum retry attempts

### DIFF
--- a/src/store/onboarding/actions.js
+++ b/src/store/onboarding/actions.js
@@ -143,8 +143,6 @@ export function createNewOrganization(
     } catch (error) {
       dispatch(hideSpinnerOverlay());
       await dispatch(unlockSafeDeployment());
-      // Force updating app state
-      await dispatch(checkAppState());
       throw error;
     }
   };

--- a/src/store/onboarding/actions.js
+++ b/src/store/onboarding/actions.js
@@ -142,6 +142,9 @@ export function createNewOrganization(
       await dispatch(unlockSafeDeployment());
     } catch (error) {
       dispatch(hideSpinnerOverlay());
+      await dispatch(unlockSafeDeployment());
+      // Force updating app state
+      await dispatch(checkAppState());
       throw error;
     }
   };


### PR DESCRIPTION
With `unlockSafeDeployment()`, the loading view disappears when the `createNewOrganization` organization action fails.
I'm not sure if `checkAppState()` is needed though. 

Closes #216