### PR TITLE
Remove donation note component in dashboard view

### DIFF
--- a/src/components/DonationNote.js
+++ b/src/components/DonationNote.js
@@ -1,3 +1,4 @@
+// This component was used in the dashboard view in 2021 but was removed indefinitely
 import { Box, Typography } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
 import { DateTime } from 'luxon';

--- a/src/views/Dashboard.js
+++ b/src/views/Dashboard.js
@@ -19,7 +19,6 @@ import AppNote from '~/components/AppNote';
 import BalanceDisplay from '~/components/BalanceDisplay';
 import ButtonSend from '~/components/ButtonSend';
 import CenteredHeading from '~/components/CenteredHeading';
-import DonationNote from '~/components/DonationNote';
 import Drawer from '~/components/Drawer';
 import Header from '~/components/Header';
 import LastInteractions from '~/components/LastInteractions';
@@ -151,7 +150,6 @@ const Dashboard = () => {
         <Container maxWidth="sm">
           <BalanceDisplay />
           <AppNote />
-          <DonationNote />
           <Box my={2}>
             <DashboardSearch />
           </Box>


### PR DESCRIPTION
Keeping the donation note component but removing the use of it in the user dashboard as per urgent request from Blanka. Previously requested but medium priority.

Closes issue https://github.com/CirclesUBI/circles-myxogastria/issues/241