### PR TITLE
ci: update actions/setup-node@v2 & simplify cache

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -15,22 +15,14 @@ jobs:
         run: echo ::set-output name=NODE_VERSION::$(cat .nvmrc)
 
       - name: Setup node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
+          cache: 'npm'
           node-version: '${{ steps.nvmrc.outputs.NODE_VERSION }}'
-
-      - name: Cache Node.js modules
-        uses: actions/cache@v2
-        with:
-          # npm cache files are stored in `~/.npm` on Linux/macOS
-          path: ~/.npm
-          key: ${{ runner.OS }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.OS }}-node-
-            ${{ runner.OS }}-
 
       - name: Setup env file
         run: cp .env.example .env
 
       - run: npm install
+      
       - run: npm run test


### PR DESCRIPTION
Small change, updating the action and using the native caching, see https://github.com/actions/setup-node#caching-packages-dependencies