### PR TITLE
Replae overlap=circle by overlap=circular

### DIFF
--- a/src/components/ActivityStream.js
+++ b/src/components/ActivityStream.js
@@ -385,7 +385,7 @@ const ActivityStreamAvatars = ({ addressOrigin, addressTarget }) => {
         horizontal: 'right',
       }}
       badgeContent={<Avatar address={addressTarget} size="tiny" />}
-      overlap="circle"
+      overlap="circular"
     >
       <Avatar address={addressOrigin} size="tiny" />
     </Badge>

--- a/src/components/AvatarWithQR.js
+++ b/src/components/AvatarWithQR.js
@@ -27,7 +27,7 @@ const AvatarWithQR = ({ address, ...props }) => {
       }}
       badgeContent={<IconQR className={classes.avatarBadgeIcon} />}
       className={classes.avatarBadge}
-      overlap="circle"
+      overlap="circular"
     >
       <Avatar address={address} {...props} />
     </Badge>

--- a/src/views/Profile.js
+++ b/src/views/Profile.js
@@ -123,7 +123,7 @@ const Profile = () => {
                   trustStatus={trustStatus}
                 />
               }
-              overlap="circle"
+              overlap="circular"
             >
               <Avatar address={address} size="large" />
             </Badge>


### PR DESCRIPTION
 I get this error in the browser console:

```
Warning: Failed prop type: Material-UI: `overlap="circle"` was deprecated. Use `overlap="circular"` instead.
```