### PR TITLE
Review tc transition

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -374,7 +374,7 @@
   },
   "TutorialTransition": {
     "slideBody11": "The issuance rate of CRC will increase. Instead of 8 CRC a day, you will now receive 1 CRC an hour (24 CRC a day).",
-    "slideBody12": "With the current changes, Circles users worldwide can share the same value of 1 CRC = 1 hour. This helps to keep the value of UBI more stable across bordes.",
+    "slideBody12": "With the current changes, Circles users worldwide can share the same value of 1 CRC = 1 hour. This helps to keep the value of UBI more stable across borders.",
     "slideBody21": "The increase in your daily UBI will also work retroactively and make your balance increase based on the amount of time you've spent at Circles. If you were holding 50 CRC you will now see around 150 CRC. Basically, your balance will tripple.",
     "slideBody22": "Another change is that we are now displaying balances with a demurrage or decay rate.",
     "slideBodyLink": "Read more here!",

--- a/locales/en.json
+++ b/locales/en.json
@@ -373,7 +373,7 @@
     "slideHeading3": "Share Trust"
   },
   "TutorialTransition": {
-    "slideBody11": "The issuance rate of CRC will increase. Instead of 8 CRC a day, you will now receive 1 CRC an hour - 24 a day.",
+    "slideBody11": "The issuance rate of CRC will increase. Instead of 8 CRC a day, you will now receive 1 CRC an hour (24 CRC a day).",
     "slideBody12": "With the current changes, Circles users worldwide can share the same value of 1 CRC = 1 hour. This helps to keep the value of UBI more stable across bordes.",
     "slideBody21": "The increase in your daily UBI will also work retroactively and make your balance increase based on the amount of time you've spent at Circles. If you were holding 50 CRC you will now see around 150 CRC. Basically, your balance will tripple.",
     "slideBody22": "Another change is that we are now displaying balances with a demurrage or decay rate.",


### PR DESCRIPTION
I'm reviewing the TC transition and found some things:
- The following text includes a slash that can be confused with a minus symbol because there are digits in the text too. I find it more clear if we use parenthesis. `you will now receive 1 CRC an hour - 24 a day.`
- Corrected a typo: `bordes` -> `borders`