### PR TITLE
Remove prop onOpen from Drawer

### DIFF
--- a/src/components/Drawer.js
+++ b/src/components/Drawer.js
@@ -29,10 +29,6 @@ const DrawerElement = () => {
 
   const isExpanded = !!useRouteMatch(`(${[MY_PROFILE_PATH].join('|')})`);
 
-  const onOpen = () => {
-    // Do nothing ...
-  };
-
   const onClose = () => {
     history.push(DASHBOARD_PATH);
   };
@@ -45,7 +41,6 @@ const DrawerElement = () => {
       }}
       open={isExpanded}
       onClose={onClose}
-      onOpen={onOpen}
     >
       <Container disableGutters maxWidth="sm">
         <Switch location={location}>


### PR DESCRIPTION
The switch from SwipeableDrawer to Drawer means the prop onOpen is no longer defined and this causes a warning in the console. Resolved by removing onOpen