### PR TITLE
Change how nonce is generated from name

### DIFF
--- a/src/services/safe.js
+++ b/src/services/safe.js
@@ -25,13 +25,15 @@ export function generateDeterministicNonce(address) {
 // Returns a deterministic CREATE2 nonce from a string to predict a
 // to-be-deployed Safe address. This is useful for generating nonces from
 // usernames.
+// Using simple insecure string hash https://gist.github.com/jlevy/c246006675becc446360a798e2b2d781
 export function generateDeterministicNonceFromName(str) {
-  // Convert each character in the string to its regarding character code
-  const charCodeStr = str.split('').reduce((acc, char) => {
-    return `${acc}${char.charCodeAt()}`;
+  const charCodeStr = str.split('').reduce((nonce, char) => {
+    const code = char.charCodeAt();
+    nonce = (nonce << 5) - nonce + code;
+    return nonce & nonce;
   }, '');
-  // Make this number smaller
-  return parseInt(charCodeStr.slice(0, 30)) % 123456789;
+
+  return Math.abs(charCodeStr);
 }
 
 export function getNonce() {

--- a/test/nonce.test.js
+++ b/test/nonce.test.js
@@ -1,5 +1,6 @@
 import {
   generateRandomNonce,
+  generateDeterministicNonceFromName,
   getNonce,
   hasNonce,
   removeNonce,
@@ -30,5 +31,12 @@ describe('Safe service', () => {
     removeNonce();
 
     expect(hasNonce()).toBe(false);
+  });
+
+  it('should generate a deterministic nonce from name that is different from a similar name', () => {
+    const nonce1 = generateDeterministicNonceFromName('test20220104');
+    const nonce2 = generateDeterministicNonceFromName('test20220105');
+
+    expect(nonce1).not.toEqual(nonce2);
   });
 });

--- a/test/nonce.test.js
+++ b/test/nonce.test.js
@@ -1,6 +1,6 @@
 import {
-  generateRandomNonce,
   generateDeterministicNonceFromName,
+  generateRandomNonce,
   getNonce,
   hasNonce,
   removeNonce,
@@ -34,9 +34,14 @@ describe('Safe service', () => {
   });
 
   it('should generate a deterministic nonce from name that is different from a similar name', () => {
-    const nonce1 = generateDeterministicNonceFromName('test20220104');
-    const nonce2 = generateDeterministicNonceFromName('test20220105');
+    const accountName1 = 'test20220104';
+    const accountName2 = 'test20220105';
+
+    const nonce1 = generateDeterministicNonceFromName(accountName1);
+    const nonce2 = generateDeterministicNonceFromName(accountName2);
+    const nonce3 = generateDeterministicNonceFromName(accountName2);
 
     expect(nonce1).not.toEqual(nonce2);
+    expect(nonce2).toBe(nonce3); // Deterministic
   });
 });


### PR DESCRIPTION
Hi, I looked into https://github.com/CirclesUBI/circles-myxogastria/issues/279 and I found that there is a better way to generate a number (nonce) from a string. I assume that should already solve most of the issues related to the same nonce generated for similar names (strings).
WDYT?

Close https://github.com/CirclesUBI/circles-myxogastria/issues/279