### PR TITLE
Reduced number of hops when retrying transfer after updateTransferSteps fail

### DIFF
--- a/src/store/token/actions.js
+++ b/src/store/token/actions.js
@@ -260,7 +260,7 @@ async function loopTransfer(
           to,
           value,
           paymentNote,
-          hops,
+          hops - 1,
           attemptsLeft - 1,
           errorsMessages.concat(
             ' ',


### PR DESCRIPTION
This fix was missed in PR #581 
Related to issue #580 

If update fails, then the transfer loop should retry with fewer hops, not the same number of hops.