### PR TITLE
Fix HumbleAlert color and html interpretation

### DIFF
--- a/src/components/AppNote.js
+++ b/src/components/AppNote.js
@@ -89,6 +89,7 @@ const AppNote = ({ messageVersion }) => {
         color={colorSelector(color)}
         icon={icon}
         iconColor={iconColorSelector(iconColor)}
+        parseHtml
       >
         {message}
       </HumbleAlert>

--- a/src/components/HumbleAlert.js
+++ b/src/components/HumbleAlert.js
@@ -25,6 +25,15 @@ const useStyles = makeStyles((theme) => {
         },
       },
     },
+    alertHtmlChildren: {
+      '& a': {
+        textDecoration: 'none',
+        color: theme.custom.colors.blueRibbon,
+        '&:hover': {
+          textDecoration: 'underline',
+        },
+      },
+    },
     alertIcon: {
       color: theme.palette.grey['800'],
       '& path': {
@@ -34,7 +43,13 @@ const useStyles = makeStyles((theme) => {
   };
 });
 
-const HumbleAlert = ({ children, icon, color, iconColor }) => {
+const HumbleAlert = ({
+  children,
+  icon,
+  color,
+  iconColor,
+  parseHtml = false,
+}) => {
   const classes = useStyles({ color, iconColor });
   const IconElement = iconSelector(icon);
 
@@ -44,10 +59,13 @@ const HumbleAlert = ({ children, icon, color, iconColor }) => {
       icon={<IconElement className={classes.alertIcon} fontSize="inherit" />}
       severity="info"
     >
-      <div
-        className={classes.alertContent}
-        dangerouslySetInnerHTML={{ __html: children }}
-      />
+      {parseHtml && (
+        <div
+          className={classes.alertHtmlChildren}
+          dangerouslySetInnerHTML={{ __html: children }}
+        />
+      )}
+      {!parseHtml && children}
     </Alert>
   );
 };
@@ -57,6 +75,7 @@ HumbleAlert.propTypes = {
   color: PropTypes.string,
   icon: PropTypes.string,
   iconColor: PropTypes.string,
+  parseHtml: PropTypes.bool,
 };
 
 export default HumbleAlert;

--- a/src/views/Error.js
+++ b/src/views/Error.js
@@ -8,6 +8,7 @@ import DialogBurn from '~/components/DialogBurn';
 import HumbleAlert from '~/components/HumbleAlert';
 import View from '~/components/View';
 import translate from '~/services/locale';
+import { colors } from '~/styles/theme';
 
 const CriticalError = () => {
   const { app, wallet, safe, token } = useSelector((state) => state);
@@ -37,7 +38,11 @@ const CriticalError = () => {
         <AppNote messageVersion="error" />
         {app.errorMessage && (
           <Box my={2} style={{ wordBreak: 'break-word' }}>
-            <HumbleAlert>
+            <HumbleAlert
+              color={colors.fountainBlueLighter}
+              icon="IconTriangleWarning"
+              iconColor={colors.whiteAlmost}
+            >
               <Typography gutterBottom>{app.errorMessage}</Typography>
               {wallet.address && (
                 <Typography component="p" variant="caption">


### PR DESCRIPTION
## Reason
PR #521 introduced a problem for HumbleAlert with child components.
The color was also not specified in a HumbleAlert in Error view.

## Before:
![Screenshot from 2023-02-10 13-10-57](https://user-images.githubusercontent.com/20553836/218132475-ff45a765-bc14-46ff-bb7a-db2c01052fa2.png)

## After:
![Screenshot from 2023-02-10 16-39-15](https://user-images.githubusercontent.com/20553836/218132574-76ff4ffb-1bf8-443c-b844-f7c30a28019e.png)


