### PR TITLE
Correct pink shadow so items are clickable

### DIFF
--- a/src/components/PinkShadow.js
+++ b/src/components/PinkShadow.js
@@ -24,6 +24,7 @@ const useStyles = makeStyles((theme) => {
       background: theme.custom.gradients.pinkShade,
       opacity: 0,
       transition: 'opacity 0.1s',
+      zIndex: theme.zIndex.layer0,
     },
     isPinkShadow: {
       opacity: '1',

--- a/src/styles/theme.js
+++ b/src/styles/theme.js
@@ -183,6 +183,7 @@ export default createTheme({
     qrCodeScannerSpinner: 11000,
     qrCodeScannerVideo: 12000,
     spinnerOverlay: 20000,
+    layer0: -10,
     layer1: 10,
     layer2: 20,
     backgroundCurvedWrapper: 0,


### PR DESCRIPTION
I think it is good for temporary solution as items are clicked but some problems occurs which could be solved by replacing a shadow with version which is less height...
![Screenshot from 2023-02-22 10-45-24](https://user-images.githubusercontent.com/95082155/220592901-00a57e76-e1a4-4a73-8736-3d1c33216716.png)
