### PR TITLE
Don't call getTransactionReceipt if txHash is not defined

### DIFF
--- a/src/store/activity/actions.js
+++ b/src/store/activity/actions.js
@@ -68,7 +68,9 @@ export function checkPendingActivities() {
 
     for await (const category of CATEGORIES) {
       activity.categories[category].activities.forEach(async (activity) => {
-        if (!activity.isPending) {
+        // We only need check pending activities and activities without
+        // txHash are not ready to be checked.
+        if (!activity.isPending || !activity.txHash) {
           return;
         }
 


### PR DESCRIPTION
Closes: https://github.com/CirclesUBI/circles-myxogastria/issues/641

As a first step verify txHash is defined.
If this does not help we can catch the error or validate further.