### PR TITLE
765 note of transfers not appearing in activity log

### DIFF
--- a/src/components/ActivityStream.js
+++ b/src/components/ActivityStream.js
@@ -146,7 +146,7 @@ const ActivityStreamList = ({
           const createdAtDate =
             createdAt || DateTime.fromSeconds(timestamp).toISO();
 
-          const txHashUpdated = txHash || transactionHash || hash;
+          const txHashUpdated = txHash || transactionHash;
 
           const item = (
             <Grid item key={key} xs={12}>

--- a/src/components/ActivityStream.js
+++ b/src/components/ActivityStream.js
@@ -146,7 +146,7 @@ const ActivityStreamList = ({
           const createdAtDate =
             createdAt || DateTime.fromSeconds(timestamp).toISO();
 
-          const txHashUpdated = txHash || transactionHash;
+          const txHashUpdated = txHash || transactionHash || hash;
 
           const item = (
             <Grid item key={key} xs={12}>

--- a/src/store/activity/reducers.js
+++ b/src/store/activity/reducers.js
@@ -79,6 +79,7 @@ function mergeActivities(currentActivities, newActivities) {
         createdAt: DateTime.fromSeconds(activity.timestamp).toISO(),
         data: activity.data,
         type: activity.type,
+        txHash: activity.transactionHash,
       });
 
       // Generate a hash so we can compare it


### PR DESCRIPTION
Fix #765 
Fix #757 

- [x] Tested working notes for individual accounts and shared accounts 
- [x] Checked if news are working and other activity log functionalities
- [x] Clicked through app for more veryfication and bug spotting
- [x] Notice duplicates in notifications whle sending, information doesn't clear properly - that one is current behaviour so it is not a result of this code being added - issue added here - https://github.com/CirclesUBI/circles-myxogastria/issues/768